### PR TITLE
Icon dropdown visibility fix

### DIFF
--- a/FaLinksPropertyEditor/App_Plugins/FaLinksPropertyEditor/falinks.propertyeditor.html
+++ b/FaLinksPropertyEditor/App_Plugins/FaLinksPropertyEditor/falinks.propertyeditor.html
@@ -5,7 +5,7 @@
                 <div class="list-view-falink list-view-falink-single" ng-repeat="item in model.value">
 
                     <i class="list-view-falink__sort-handle icon-navigation"></i>
-                    <div ng-show="vm.showIcon">
+                    <div ng-hide="vm.hideIcon">
                         <div ng-show="!item.svg" class="list-view-falink__icon-add">
                             <a ng-click="addIcon(item)" href="" class="-full-width-input" prevent-default>
                                 <i class="icon icon-add"></i> Icon

--- a/FaLinksPropertyEditor/App_Plugins/FaLinksPropertyEditor/js/falinks.propertyeditor.controller.js
+++ b/FaLinksPropertyEditor/App_Plugins/FaLinksPropertyEditor/js/falinks.propertyeditor.controller.js
@@ -5,7 +5,7 @@
     vm.showPrompt = showPrompt;
     vm.hidePrompt = hidePrompt;
     vm.remove = remove;
-    vm.hideIcon = true;
+    vm.hideIcon = false;
 
     function add() {
         const item = {
@@ -180,7 +180,7 @@
 
     vm.init = function () {
         if ($scope.model.config && $scope.model.config.hideIconPicker) {
-            vm.hideIcon = $scope.model.config.hideIconPicker;
+            vm.hideIcon = $scope.model.config.hideIconPicker == true;
         }
     }
     vm.init();


### PR DESCRIPTION
In 2f340a19343c6c7ec3145921ceae4aed019c75ee an option was added to control the visibility of the icon dropdown with a prevalue setting.

There seems to be a mismatch with variable names across the view and controller:

https://github.com/mjbarlow/Font-Awesome-Links-Property-Editor/blob/650865f7fa853f583ce7a3f726869887580a48d1/FaLinksPropertyEditor/App_Plugins/FaLinksPropertyEditor/falinks.propertyeditor.html#L8

https://github.com/mjbarlow/Font-Awesome-Links-Property-Editor/blob/650865f7fa853f583ce7a3f726869887580a48d1/FaLinksPropertyEditor/App_Plugins/FaLinksPropertyEditor/js/falinks.propertyeditor.controller.js#L8

https://github.com/mjbarlow/Font-Awesome-Links-Property-Editor/blob/650865f7fa853f583ce7a3f726869887580a48d1/FaLinksPropertyEditor/App_Plugins/FaLinksPropertyEditor/js/falinks.propertyeditor.controller.js#L182-L184

This PR should address and resolve this issue which prevents the icon drop down from appearing